### PR TITLE
Feature: Add note categories

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 
 class CategoryController extends Controller
 {
-    public function index(Request $request)
+    public function index(Request $request): View
     {
         $categories = $request->user()->categories;
 

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\CategoryRequest;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 class CategoryController extends Controller
@@ -13,5 +16,28 @@ class CategoryController extends Controller
         return view('categories.index', [
             'categories' => $categories,
         ]);
+    }
+
+    public function create(): View
+    {
+        return view('categories.form');
+    }
+
+    public function store(CategoryRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+        $userCategories = $request->user()->categories();
+
+        $category = $userCategories->where('id', $request->get('category_id'))
+            ->first();
+
+        if (!$category) {
+            $category = $userCategories->make();
+        }
+
+        $category->fill($validated);
+        $category->save();
+
+        return redirect(route('categories.index'))->with('status', 'Category Saved');
     }
 }

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\CategoryRequest;
+use App\Models\Category;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -39,5 +40,14 @@ class CategoryController extends Controller
         $category->save();
 
         return redirect(route('categories.index'))->with('status', 'Category Saved');
+    }
+
+    public function edit(Request $request, Category $category): View
+    {
+        abort_if($category->user_id !== $request->user()->id, 404);
+
+        return view('categories.form', [
+            'category' => $category,
+        ]);
     }
 }

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class CategoryController extends Controller
+{
+    public function index(Request $request)
+    {
+        $categories = $request->user()->categories;
+
+        return view('categories.index', [
+            'categories' => $categories,
+        ]);
+    }
+}

--- a/app/Http/Requests/CategoryRequest.php
+++ b/app/Http/Requests/CategoryRequest.php
@@ -14,6 +14,10 @@ class CategoryRequest extends FormRequest
             return $query->where('user_id', $this->user()->id);
         });
 
+        if (isset($this->category_id)) {
+            $uniqueNameRule->ignore($this->category_id);
+        }
+
         return [
             'name' => ['required', 'max:40', $uniqueNameRule],
         ];

--- a/app/Http/Requests/CategoryRequest.php
+++ b/app/Http/Requests/CategoryRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class CategoryRequest extends FormRequest
+{
+    public function rules()
+    {
+        $uniqueNameRule = Rule::unique('categories')->where(function (Builder $query): Builder {
+            return $query->where('user_id', $this->user()->id);
+        });
+
+        return [
+            'name' => ['required', 'max:40', $uniqueNameRule],
+        ];
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Category extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -40,4 +41,9 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public function categories(): HasMany
+    {
+        return $this->hasMany(Category::class);
+    }
 }

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    protected static $counter = 1;
+
+    public function definition()
+    {
+        return [
+            'user_id' => User::factory(),
+            'name' => 'Category ' . self::$counter++,
+        ];
+    }
+}

--- a/database/migrations/2025_01_22_211858_create_categories_table.php
+++ b/database/migrations/2025_01_22_211858_create_categories_table.php
@@ -15,7 +15,7 @@ class CreateCategoriesTable extends Migration
             $table->string('name', 40);
             $table->timestamps();
 
-            $table->index(['user_id', 'name']);
+            $table->unique(['user_id', 'name']);
         });
     }
 

--- a/database/migrations/2025_01_22_211858_create_categories_table.php
+++ b/database/migrations/2025_01_22_211858_create_categories_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCategoriesTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(User::class)->constrained();
+            $table->string('name', 40);
+            $table->timestamps();
+
+            $table->index(['user_id', 'name']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('categories');
+    }
+}

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Category;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class CategorySeeder extends Seeder
+{
+    public function run()
+    {
+        User::all()->each(function ($user) {
+            Category::factory()
+                ->count(3)
+                ->create([
+                    'user_id' => $user->id,
+                ]);
+        });
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,6 +15,7 @@ class DatabaseSeeder extends Seeder
     {
         // \App\Models\User::factory(10)->create();
         $this->call(UserSeeder::class);
+        $this->call(CategorySeeder::class);
         $this->call(NoteSeeder::class);
     }
 }

--- a/resources/views/categories/form.blade.php
+++ b/resources/views/categories/form.blade.php
@@ -1,0 +1,43 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+
+    <div class="row justify-content-center">
+
+        <div class="col-md-8">
+
+            <div class="card">
+
+                <div class="card-header">{{ __(isset($category) ? 'Edit Category' : 'Create Category') }}</div>
+
+                <div class="card-body">
+
+                    <form action="{{ route('categories.store', $category->id ?? null) }}" method="post">
+                        @csrf
+
+                        <div class="form-group">
+                            <label for="name">{{ __('Name') }}*</label>
+                            <input type="text" name="name" id="name" placeholder="Name" class="form-control @error('name') is-invalid @enderror" value="{{ isset($category) ? $category->name : '' }}">
+
+                            @error('name')
+                                <span class="invalid-feedback" role="alert">
+                                    <strong>{{ $message }}</strong>
+                                </span>
+                            @enderror
+                        </div>
+
+                        <button type="submit" class="btn btn-primary">{{ __('Save') }}</button>
+                    </form>
+
+                </div>
+
+            </div>
+
+        </div>
+
+    </div>
+
+</div>
+
+@endsection

--- a/resources/views/categories/form.blade.php
+++ b/resources/views/categories/form.blade.php
@@ -13,7 +13,7 @@
 
                 <div class="card-body">
 
-                    <form action="{{ route('categories.store', $category->id ?? null) }}" method="post">
+                    <form action="{{ route('categories.store', ['category_id' => $category->id ?? null]) }}" method="post">
                         @csrf
 
                         <div class="form-group">

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -5,7 +5,7 @@
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="card">
-                <div class="card-header">{{ __('Dashboard') }}</div>
+                <div class="card-header">{{ __('Categories') }}</div>
 
                 <div class="card-body">
                     @if (session('status'))
@@ -14,9 +14,11 @@
                         </div>
                     @endif
 
-                    <a href="{{ route('note.list') }}">{{ __('View Notes') }}</a>
-                    <br />
-                    <a href="{{ route('categories.index') }}">{{ __('View Categories') }}</a>
+                    <ul class="list-group list-group-flush">
+                        @foreach ($categories as $category)
+                            <li class="list-group-item"><a href="#">{{ $category->name }}</a></li>
+                        @endforeach
+                    </ul>
                 </div>
             </div>
         </div>

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -16,7 +16,7 @@
 
                     <ul class="list-group list-group-flush">
                         @foreach ($categories as $category)
-                            <li class="list-group-item"><a href="#">{{ $category->name }}</a></li>
+                            <li class="list-group-item"><a href="{{ route('categories.edit', $category) }}">{{ $category->name }}</a></li>
                         @endforeach
                     </ul>
                 </div>

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -5,7 +5,7 @@
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="card">
-                <div class="card-header">{{ __('Categories') }}</div>
+                <div class="card-header">{{ __('Categories') }}<a href="{{ route('categories.create') }}" class="float-right btn btn-primary btn-sm">{{ __('Create Category') }}</a></div>
 
                 <div class="card-body">
                     @if (session('status'))

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,5 +38,6 @@ Route::group([
     });
 
     // Category routes
-    Route::resource('categories', CategoryController::class)->only(['index']);
+    Route::resource('categories', CategoryController::class)
+        ->only(['index', 'create', 'store']);
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,5 +39,5 @@ Route::group([
 
     // Category routes
     Route::resource('categories', CategoryController::class)
-        ->only(['index', 'create', 'store']);
+        ->only(['index', 'create', 'store', 'edit']);
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\CategoryController;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\NoteController;
 
@@ -24,7 +25,7 @@ Route::group([
     'middleware' => ['auth']
 ], function () {
     Route::get('/home', [App\Http\Controllers\HomeController::class, 'index'])->name('home');
-    
+
     // Note Routes
     Route::group([
         'as'            => 'note.',
@@ -35,4 +36,7 @@ Route::group([
         Route::get('/{note_id}', [NoteController::class, 'view'])->name('view');
         Route::post('/{note_id?}', [NoteController::class, 'store'])->name('store');
     });
+
+    // Category routes
+    Route::resource('categories', CategoryController::class)->only(['index']);
 });

--- a/tests/Feature/CategoryControllerTest.php
+++ b/tests/Feature/CategoryControllerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CategoryControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Collection $categories;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+
+        $this->categories = Category::factory()
+            ->count(5)
+            ->create([
+                'user_id' => $this->user->id,
+            ]);
+
+        Category::factory()
+            ->count(3)
+            ->for(User::factory())
+            ->create();
+    }
+
+    public function testOnlyAuthenticatedUsersSeeTheListOfCategories(): void
+    {
+        $response = $this->get(route('categories.index'));
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function testListOfCategoriesCanBeFetched(): void
+    {
+        $this->actingAs($this->user);
+
+        $response = $this->get(route('categories.index'));
+
+        $response->assertStatus(200)
+            ->assertViewIs('categories.index')
+            ->assertViewHas('categories', function ($categories): bool {
+                return $categories->count() === 5;
+            });
+    }
+}

--- a/tests/Feature/CategoryControllerTest.php
+++ b/tests/Feature/CategoryControllerTest.php
@@ -13,6 +13,7 @@ class CategoryControllerTest extends TestCase
     use RefreshDatabase;
 
     private User $user;
+    private User $secondUser;
     private Collection $categories;
 
     public function setUp(): void
@@ -27,10 +28,12 @@ class CategoryControllerTest extends TestCase
                 'user_id' => $this->user->id,
             ]);
 
+        $this->secondUser = User::factory()->create();
         Category::factory()
             ->count(3)
-            ->for(User::factory())
-            ->create();
+            ->create([
+                'user_id' => $this->secondUser->id,
+            ]);
     }
 
     public function testOnlyAuthenticatedUsersSeeTheListOfCategories(): void
@@ -139,5 +142,177 @@ class CategoryControllerTest extends TestCase
         $response->assertSessionHasErrors([
             'name' => 'The name may not be greater than 40 characters.',
         ]);
+    }
+    public function testOnlyAuthenticatedUsersCanViewEditCategoriesPage(): void
+    {
+        $category = $this->categories->first();
+        $response = $this->get(route('categories.edit', $category));
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function testAuthenticatedUsersCanViewEditCategoriesPage(): void
+    {
+        $this->actingAs($this->user);
+
+        $category = $this->categories->first();
+        $response = $this->get(route('categories.edit', $category));
+
+        $response->assertStatus(200)
+            ->assertViewIs('categories.form');
+    }
+
+    public function testAUserCannotEditAnotherUsersCategory(): void
+    {
+        $this->actingAs($this->user);
+
+        $category = $this->secondUser->categories->first();
+        $response = $this->get(route('categories.edit', $category));
+
+        $response->assertStatus(404);
+    }
+
+    public function testOnlyAuthenticatedUsersCanUpdateCategories(): void
+    {
+        $category = $this->categories->first();
+        $response = $this->post(route('categories.store', ['category_id' => $category->id]), [
+            'name' => 'Updated Category',
+        ]);
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function testAuthenticatedUsersCanUpdateCategories(): void
+    {
+        $this->actingAs($this->user);
+
+        $categoryData = [
+            'name' => 'Updated Category',
+        ];
+
+        $category = $this->categories->first();
+        $response = $this->post(
+            route('categories.store', ['category_id' => $category->id]),
+            $categoryData
+        );
+
+        $response->assertRedirect(route('categories.index'));
+
+        $categoryData['user_id'] = $this->user->id;
+        $this->assertDatabaseHas('categories', $categoryData);
+    }
+
+    public function testAUserCannotUpdateAnotherUsersCategory(): void
+    {
+        $this->actingAs($this->user);
+
+        $category = $this->secondUser->categories->first();
+        $response = $this->post(route('categories.store', ['category_id' => $category->id]),[
+            'name' => 'Updated Category',
+        ]);
+
+        $response->assertRedirect(route('categories.index'));
+
+        // The second user's category should not be updated
+        $this->assertDatabaseMissing('categories', [
+            'id' => $category->id,
+            'user_id' => $this->secondUser->id,
+            'name' => 'Updated Category',
+        ]);
+
+        // A new category should be created for the authenticated user
+        $this->assertDatabaseHas('categories', [
+            'user_id' => $this->user->id,
+            'name' => 'Updated Category',
+        ]);
+    }
+
+    public function testACategoryCannotBeUpdatedWithAnEmptyName(): void
+    {
+        $this->actingAs($this->user);
+
+        $category = $this->categories->first();
+        $response = $this->post(route('categories.store', ['category_id' => $category->id]), [
+            'name' => null,
+        ]);
+
+        $response->assertSessionHasErrors([
+            'name' => 'The name field is required.',
+        ]);
+    }
+
+    public function testCategoryNamesMustBeUniqueForAUserWhenUpdated(): void
+    {
+        User::all()->each(function ($user) {
+            Category::factory()->create([
+                    'user_id' => $user->id,
+                    'name' => 'Unique Category',
+                ]);
+        });
+
+        $this->actingAs($this->user);
+
+        $category = $this->categories->first();
+        $response = $this->post(route('categories.store', ['category_id' => $category->id]), [
+            'name' => 'Unique Category',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'name' => 'The name has already been taken.',
+        ]);
+    }
+
+    public function testACategoryCanBeUpdatedWithTheSameName(): void
+    {
+        $this->actingAs($this->user);
+
+        $category = $this->categories->first();
+        $response = $this->post(route('categories.store', ['category_id' => $category->id]), [
+            'name' => $category->name,
+        ]);
+
+        $response->assertRedirect(route('categories.index'));
+
+        $categoryData['user_id'] = $this->user->id;
+        $this->assertDatabaseHas('categories', $categoryData);
+    }
+
+    public function testCategoryNamesCannotBeMoreThan40CharactersWhenUpdated(): void
+    {
+        $this->actingAs($this->user);
+
+        $category = $this->categories->first();
+        $response = $this->post(route('categories.store', ['category_id' => $category->id]), [
+            'name' => str_repeat('a', 41),
+        ]);
+
+        $response->assertSessionHasErrors([
+            'name' => 'The name may not be greater than 40 characters.',
+        ]);
+    }
+
+    public function testACategoryCanHaveTheSameNameAsAnotherUser(): void
+    {
+        Category::factory()->create([
+            'user_id' => $this->secondUser->id,
+            'name' => 'User 2 Category',
+        ]);
+
+        $this->actingAs($this->user);
+
+        $categoryData = [
+            'name' => 'User 2 Category',
+        ];
+
+        $category = $this->categories->first();
+        $response = $this->post(
+            route('categories.store', ['category_id' => $category->id]),
+            $categoryData
+        );
+
+        $response->assertRedirect(route('categories.index'));
+
+        $categoryData['user_id'] = $this->user->id;
+        $this->assertDatabaseHas('categories', $categoryData);
     }
 }

--- a/tests/Feature/CategoryControllerTest.php
+++ b/tests/Feature/CategoryControllerTest.php
@@ -52,4 +52,92 @@ class CategoryControllerTest extends TestCase
                 return $categories->count() === 5;
             });
     }
+
+    public function testOnlyAuthenticatedUsersCanViewCreateCategoriesPage(): void
+    {
+        $response = $this->get(route('categories.create'));
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function testAuthenticatedUsersCanViewCreateCategoriesPage(): void
+    {
+        $this->actingAs($this->user);
+
+        $response = $this->get(route('categories.create'));
+
+        $response->assertStatus(200)
+            ->assertViewIs('categories.form');
+    }
+
+    public function testOnlyAuthenticatedUsersCanCreateCategories(): void
+    {
+        $response = $this->post(route('categories.store'), [
+            'name' => 'New Category',
+        ]);
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function testAuthenticatedUsersCanCreateCategories(): void
+    {
+        $this->actingAs($this->user);
+
+        $categoryData = [
+            'name' => 'New Category',
+        ];
+
+        $response = $this->post(route('categories.store', ['category_id' => 1]), $categoryData);
+
+        $response->assertRedirect(route('categories.index'));
+
+        $categoryData['user_id'] = $this->user->id;
+        $this->assertDatabaseHas('categories', $categoryData);
+    }
+
+    public function testACategoryCannotBeCreatedWithoutAName(): void
+    {
+        $this->actingAs($this->user);
+
+        $response = $this->post(route('categories.store'), [
+            'name' => null,
+        ]);
+
+        $response->assertSessionHasErrors([
+            'name' => 'The name field is required.',
+        ]);
+    }
+
+    public function testCategoryNamesMustBeUniqueForAUser(): void
+    {
+        User::all()->each(function ($user) {
+            Category::factory()->create([
+                    'user_id' => $user->id,
+                    'name' => 'Unique Category',
+                ]);
+        });
+
+        $this->actingAs($this->user);
+
+        $response = $this->post(route('categories.store'), [
+            'name' => 'Unique Category',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'name' => 'The name has already been taken.',
+        ]);
+    }
+
+    public function testCategoryNamesCannotBeMoreThan40Characters(): void
+    {
+        $this->actingAs($this->user);
+
+        $response = $this->post(route('categories.store'), [
+            'name' => str_repeat('a', 41),
+        ]);
+
+        $response->assertSessionHasErrors([
+            'name' => 'The name may not be greater than 40 characters.',
+        ]);
+    }
 }


### PR DESCRIPTION
## Description
This PR adds the ability to add, edit and view categories and then assign them to notes.

## Todo
This PR is still in progress the following work is left to do.

- [X] Create the categories database table migration
- [X] Create the model and factory
- [X] Update the database seeder to include categories
- [x] Add viewing a list of categories
- [x] Add creating a new category
- [x] Add editing categories
- [ ] Create a link table between notes and categories
- [ ] Add the list of categories to the note form
- [ ] Associate the selected categories to the note on save
- [ ] Display the categories associated to a note in the notes list

## Changes in this PR
- A migration has been added to create a categories database table. A name field has been added that is not nullable, it has been restrcited to 40 characters - this felt like a conserative upper limit for a category. A foreign key for the users table has been added so that categories can be per user.
- A composite unque index has been placed on the user_id and name column in the categories table. The order has been picked so that this index can be used for just finding categories for a specific user as well as finding a specific category for a user.
- The Category model and factory have been added and the seeder has been updated to support categories.
- The categories relationship has been added to the user model.
- Index, create, store and edit routes have been created for the categories resource along.
- As has been done for notes, the store route supports creating new and editing notes.
- Acompanying tests have been added to ensure the routes have the appropropriate level of protection, verify validation and confirm storing category data works.

## Things that may need to be considered for future work
- Does there need to be pagination on the categories and notes pages